### PR TITLE
Handle dataset manager on proxy error

### DIFF
--- a/tasi/dlr/__init__.py
+++ b/tasi/dlr/__init__.py
@@ -2,7 +2,6 @@ from .dataset import (
     DLRDatasetManager,
     DLRHTVersion,
     DLRTrajectoryDataset,
-    DLRUTDatasetManager,
     DLRUTTrafficLightDataset,
     DLRUTVersion,
     ObjectClass,

--- a/tasi/dlr/__init__.py
+++ b/tasi/dlr/__init__.py
@@ -1,6 +1,5 @@
 from .dataset import (
     DLRDatasetManager,
-    DLRHTDatasetManager,
     DLRHTVersion,
     DLRTrajectoryDataset,
     DLRUTDatasetManager,
@@ -8,3 +7,8 @@ from .dataset import (
     DLRUTVersion,
     ObjectClass,
 )
+
+try:
+    from .dataset import DLRHTDatasetManager, DLRUTDatasetManager
+except ImportError:
+    pass

--- a/tasi/dlr/dataset.py
+++ b/tasi/dlr/dataset.py
@@ -261,81 +261,85 @@ class DLRDatasetManager:
 dlr_ut_records = ZenodoConnector("DLR Urban Traffic dataset", parent_id=11396371)
 DLRUTVersion = dlr_ut_records.get_version_enum()
 
+if DLRUTVersion is None:
+    logging.warning("Failed to fetch version of DLR UT dataset")
 
-class DLRUTDatasetManager(DLRDatasetManager):
-    """A manager to load the DLR UT dataset from zenodo"""
+else:
 
-    VERSION_ENUM = DLRUTVersion
-    VERSION = dlr_ut_records.get_dois()
-    """Dict[str, int]: An internal mapping between version and the zenodo id
-    """
+    class DLRUTDatasetManager(DLRDatasetManager):
+        """A manager to load the DLR UT dataset from zenodo"""
 
-    ARCHIVE = dict(
-        **{
-            v: "DLR-Urban-Traffic-dataset"
-            for v in [key for key in VERSION if key != DLRUTVersion.v1_0_0.value]
-        },
-        **{DLRUTVersion.v1_0_0.value: "DLR-UT"},
-    )
-
-    @classmethod
-    def area(cls):
-        return "urban"
-
-    def _dataset(self, variant: str, path: Path = None) -> List[str]:
-        """Searches for files in the dataset specified at ``path`` for dataset information ``variant``
-
-        Args:
-            path (Path): The path of the dataset.
-            variant (str): The dataset information to search for
-
-        Returns:
-            List[str]: The files found in the dataset for the specified dataset information
+        VERSION_ENUM = DLRUTVersion
+        VERSION = dlr_ut_records.get_dois()
+        """Dict[str, int]: An internal mapping between version and the zenodo id
         """
-        if path is None:
-            path = self._path
 
-        if not isinstance(path, Path):
-            path = Path(path)
+        ARCHIVE = dict(
+            **{
+                v: "DLR-Urban-Traffic-dataset"
+                for v in [key for key in VERSION if key != DLRUTVersion.v1_0_0.value]
+            },
+            **{DLRUTVersion.v1_0_0.value: "DLR-UT"},
+        )
 
-        # join dataset path and name
-        path = path.joinpath(self.name)
+        @classmethod
+        def area(cls):
+            return "urban"
 
-        # add type of data
-        if self.version not in [
-            DLRUTVersion.v1_0_0.value,
-            DLRUTVersion.v1_0_1.value,
-            DLRUTVersion.v1_1_0.value,
-        ]:
-            path = path.joinpath(self.DATA_TYPES[variant])
+        def _dataset(self, variant: str, path: Path = None) -> List[str]:
+            """Searches for files in the dataset specified at ``path`` for dataset information ``variant``
 
-        # add variant of data
-        path = path.joinpath(variant)
+            Args:
+                path (Path): The path of the dataset.
+                variant (str): The dataset information to search for
 
-        # return file pathes of variant
-        return [os.path.join(path, p) for p in sorted(os.listdir(path))]
+            Returns:
+                List[str]: The files found in the dataset for the specified dataset information
+            """
+            if path is None:
+                path = self._path
 
-    def traffic_lights(self, path: Path = None) -> List[str]:
-        """List of files with traffic light data.
+            if not isinstance(path, Path):
+                path = Path(path)
 
-        Args:
-            path (Path): The path of the dataset
+            # join dataset path and name
+            path = path.joinpath(self.name)
 
-        Returns:
-            List[str]: The files with traffic light data
-        """
-        return self._dataset("traffic_lights", path)
+            # add type of data
+            if self.version not in [
+                DLRUTVersion.v1_0_0.value,
+                DLRUTVersion.v1_0_1.value,
+                DLRUTVersion.v1_1_0.value,
+            ]:
+                path = path.joinpath(self.DATA_TYPES[variant])
 
-    def air_quality(self, path: Path = None) -> List[str]:
-        """List of files with air quality data.
+            # add variant of data
+            path = path.joinpath(variant)
 
-        Args:
-            path (Path): The path of the dataset
+            # return file pathes of variant
+            return [os.path.join(path, p) for p in sorted(os.listdir(path))]
 
-        Returns:
-            List[str]: The files with air quality data
-        """
-        return self._dataset("air_quality", path)
+        def traffic_lights(self, path: Path = None) -> List[str]:
+            """List of files with traffic light data.
+
+            Args:
+                path (Path): The path of the dataset
+
+            Returns:
+                List[str]: The files with traffic light data
+            """
+            return self._dataset("traffic_lights", path)
+
+        def air_quality(self, path: Path = None) -> List[str]:
+            """List of files with air quality data.
+
+            Args:
+                path (Path): The path of the dataset
+
+            Returns:
+                List[str]: The files with air quality data
+            """
+            return self._dataset("air_quality", path)
 
 
 class ObjectClass(IntEnum):
@@ -491,49 +495,52 @@ class DLRUTTrafficLightDataset(TrafficLightDataset):
 dlr_ht_records = ZenodoConnector("DLR Highway Traffic dataset", parent_id=14012005)
 DLRHTVersion = dlr_ht_records.get_version_enum()
 
+if DLRHTVersion is None:
+    logging.warning("Failed to fetch version of DLR HT dataset")
+else:
 
-class DLRHTDatasetManager(DLRDatasetManager):
-    """A manager to load the DLR HT dataset from zenodo"""
+    class DLRHTDatasetManager(DLRDatasetManager):
+        """A manager to load the DLR HT dataset from zenodo"""
 
-    VERSION_ENUM = DLRHTVersion
-    VERSION = dlr_ht_records.get_dois()
-    """Dict[str, int]: An internal mapping between version and the zenodo id
-    """
-
-    @classmethod
-    def area(cls):
-        return "highway"
-
-    @property
-    def archivename(self):
-        """The base name of the archive"""
-        return "DLR-Highway-Traffic-dataset"
-
-    def _dataset(self, variant: str, path: Path = None) -> List[str]:
-        """Searches for files in the dataset specified at ``path`` for dataset information ``variant``
-
-        Args:
-            path (Path): The path of the dataset.
-            variant (str): The dataset information to search for
-
-        Returns:
-            List[str]: The files found in the dataset for the specified dataset information
+        VERSION_ENUM = DLRHTVersion
+        VERSION = dlr_ht_records.get_dois()
+        """Dict[str, int]: An internal mapping between version and the zenodo id
         """
-        if path is None:
-            path = self._path
 
-        if not isinstance(path, Path):
-            path = Path(path)
+        @classmethod
+        def area(cls):
+            return "highway"
 
-        # join dataset path and name, type and variant
-        path = (
-            path.joinpath(self.name)
-            .joinpath(self.DATA_TYPES[variant])
-            .joinpath(variant)
-        )
+        @property
+        def archivename(self):
+            """The base name of the archive"""
+            return "DLR-Highway-Traffic-dataset"
 
-        # return file pathes of variant
-        return [os.path.join(path, p) for p in sorted(os.listdir(path))]
+        def _dataset(self, variant: str, path: Path = None) -> List[str]:
+            """Searches for files in the dataset specified at ``path`` for dataset information ``variant``
+
+            Args:
+                path (Path): The path of the dataset.
+                variant (str): The dataset information to search for
+
+            Returns:
+                List[str]: The files found in the dataset for the specified dataset information
+            """
+            if path is None:
+                path = self._path
+
+            if not isinstance(path, Path):
+                path = Path(path)
+
+            # join dataset path and name, type and variant
+            path = (
+                path.joinpath(self.name)
+                .joinpath(self.DATA_TYPES[variant])
+                .joinpath(variant)
+            )
+
+            # return file pathes of variant
+            return [os.path.join(path, p) for p in sorted(os.listdir(path))]
 
 
 class AddIndexFromCSVMixin:

--- a/tasi/io/zenodo.py
+++ b/tasi/io/zenodo.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Dict
 
 import requests
 
@@ -12,12 +13,13 @@ class ZenodoConnector:
 
     ZENODO_API: str = "https://zenodo.org/api/records"
 
-    def __init__(self, title: str, parent_id: int = None):
+    def __init__(self, title: str, parent_id: int | None = None):
         """
         Initializes the ZenodoConnector object with a given title.
 
         Args:
             title (str): The title of the dataset to query from Zenodo.
+            parent_id (int, optional): The index of the parent record.
         """
         self.title = title
         self.parent_id = parent_id
@@ -26,14 +28,14 @@ class ZenodoConnector:
         self.versions = self.get_versions()
         self.dois = self.get_dois()
 
-    def get_records(self) -> list[dict]:
+    def get_records(self) -> list[Dict]:
         """
         This method sends a GET request to the Zenodo API and retrieves all
         records matching the given title. The records are then sorted by
         their creation date.
 
         Returns:
-            list[dict]: A list of records from Zenodo, sorted by creation date.
+            list[Dict]: A list of records from Zenodo, sorted by creation date.
 
         Raises:
             requests.exceptions.RequestException: If there is an error with the HTTP request.
@@ -68,14 +70,14 @@ class ZenodoConnector:
                 f"Error retrieving data. Status code: {response.status_code}"
             )
 
-    def get_versions(self) -> dict[str]:
+    def get_versions(self) -> Dict[str, int]:
         """
         This method extracts the version information from each record and
         returns it as a dictionary, along with the latest version.
 
         Returns:
-            dict[str]: A dictionary of versions with 'v' prefixed and version numbers as keys,
-                       including the latest version.
+            Dict[str, int]: A dictionary of versions with 'v' prefixed and
+                            version numbers as keys, including the latest version.
         """
         # Get the latest version
         latest_version = {"latest": "v" + self.records[0]["metadata"]["version"]}
@@ -91,14 +93,14 @@ class ZenodoConnector:
         # Return all versions
         return {**latest_version, **versions}
 
-    def get_dois(self) -> dict[str]:
+    def get_dois(self) -> Dict[str, int]:
         """
         This method extracts the DOI information from each record and maps
         it to its respective version. It also returns the latest DOI.
 
         Returns:
-            dict[str]: A dictionary of DOIs with 'v' prefixed and version numbers as keys,
-                       including the latest DOI.
+            Dict[str, int]: A dictionary of DOIs with 'v' prefixed and version
+                            numbers as keys, including the latest DOI.
         """
         # Get the latest DOI
         latest_doi = {"latest": int(self.records[0]["doi"].split(".")[-1])}

--- a/tasi/io/zenodo.py
+++ b/tasi/io/zenodo.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 import requests
 
@@ -88,18 +88,22 @@ class ZenodoConnector:
                             version numbers as keys, including the latest version.
         """
         # Get the latest version
-        latest_version = {"latest": "v" + self.records[0]["metadata"]["version"]}
+        if self.records:
 
-        # Get all other versions
-        versions = {
-            "v"
-            + record["metadata"]["version"].replace(".", "_"): "v"
-            + record["metadata"]["version"]
-            for record in self.records
-        }
+            latest_version = {"latest": "v" + self.records[0]["metadata"]["version"]}
 
-        # Return all versions
-        return {**latest_version, **versions}
+            # Get all other versions
+            versions = {
+                "v"
+                + record["metadata"]["version"].replace(".", "_"): "v"
+                + record["metadata"]["version"]
+                for record in self.records
+            }
+
+            # Return all versions
+            return {**latest_version, **versions}
+
+        return {}
 
     def get_dois(self) -> Dict[str, int]:
         """
@@ -110,19 +114,23 @@ class ZenodoConnector:
             Dict[str, int]: A dictionary of DOIs with 'v' prefixed and version
                             numbers as keys, including the latest DOI.
         """
-        # Get the latest DOI
-        latest_doi = {"latest": int(self.records[0]["doi"].split(".")[-1])}
+        if self.records:
 
-        # Get all other DOIs
-        dois = {
-            "v" + record["metadata"]["version"]: int(record["doi"].split(".")[-1])
-            for record in self.records
-        }
+            # Get the latest DOI
+            latest_doi = {"latest": int(self.records[0]["doi"].split(".")[-1])}
 
-        # Return all DOIs
-        return {**latest_doi, **dois}
+            # Get all other DOIs
+            dois = {
+                "v" + record["metadata"]["version"]: int(record["doi"].split(".")[-1])
+                for record in self.records
+            }
 
-    def get_version_enum(self) -> Enum:
+            # Return all DOIs
+            return {**latest_doi, **dois}
+
+        return {}
+
+    def get_version_enum(self) -> Optional[Enum]:
         """
         Generates an Enum for the versions.
 
@@ -132,4 +140,5 @@ class ZenodoConnector:
         Returns:
             Enum: An Enum class representing the dataset versions.
         """
-        return Enum(self.title.replace(" ", "") + "Version", self.versions)
+        if self.versions:
+            return Enum(self.title.replace(" ", "") + "Version", self.versions)


### PR DESCRIPTION
This merge request contains the following changes:

* Return empty version entries if failing to fetch from zenodo (e.g. due to proxy configuration)
* Update type annotations